### PR TITLE
Handle policy creation query directly

### DIFF
--- a/app.py
+++ b/app.py
@@ -88,6 +88,33 @@ def es_tema_seguro(texto: str) -> bool:
     )
     return any(p in texto for p in palabras)
 
+
+def respuesta_crear_poliza(texto: str):
+    """Proporciona una respuesta directa si el usuario pregunta cómo crear una póliza."""
+    if not texto:
+        return None
+
+    pregunta = texto.lower()
+    claves = (
+        "crear poliza",
+        "crear póliza",
+        "nueva poliza",
+        "nueva póliza",
+        "alta de poliza",
+        "alta de póliza",
+    )
+
+    if any(c in pregunta for c in claves):
+        return (
+            "Para crear una póliza:\n"
+            "1. Ve al módulo Pólizas y elige 'Nueva Póliza'.\n"
+            "2. Completa el formulario correspondiente.\n"
+            "3. Guarda para finalizar. También puedes ir al formulario en "
+            "http://pruebas.localhost:3000/formulario-polizas"
+        )
+
+    return None
+
 ALLOWED_TOPICS_PROMPT = PromptTemplate(
     input_variables=["question"],
     template="""


### PR DESCRIPTION
## Summary
- Implement helper `respuesta_crear_poliza` to return quick steps for creating a policy.
- Call the helper in the `/ayuda` endpoint so users asking for policy creation instructions receive immediate guidance.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8a4eeea10832a9acacb322b11ec0b